### PR TITLE
Performance optimizations & benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,16 +12,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
@@ -51,6 +90,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -58,6 +149,78 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -69,6 +232,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "evolve"
 version = "0.3.1"
 dependencies = [
+ "criterion",
  "evolve-derive",
  "pooled",
  "rand",
@@ -94,6 +258,30 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generator"
@@ -122,6 +310,17 @@ dependencies = [
  "rand_core",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -164,10 +363,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -259,16 +479,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "pooled"
@@ -331,6 +604,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +659,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,6 +686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -423,6 +738,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +767,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -516,6 +847,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +872,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -566,6 +952,47 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -683,6 +1110,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,7 @@ dependencies = [
  "evolve-derive",
  "pooled",
  "rand",
+ "vecpool",
 ]
 
 [[package]]
@@ -653,6 +654,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,6 +852,14 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vecpool"
+version = "0.1.0"
+source = "git+https://github.com/MichaelDuPlessis/vecpool#cd944f1cb2f95c95fb73098b5854a9c372721538"
+dependencies = [
+ "rustc-hash",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -856,7 +856,8 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 [[package]]
 name = "vecpool"
 version = "0.1.0"
-source = "git+https://github.com/MichaelDuPlessis/vecpool#cd944f1cb2f95c95fb73098b5854a9c372721538"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef239a7d69660e616097879a3c66d42c3e07f5d33680a3e00e89490957c659e"
 dependencies = [
  "rustc-hash",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ parallel = ["dep:pooled"]
 rand = "0.10.0"
 pooled = { version = "0.3", optional = true }
 evolve-derive = { path = "evolve-derive", version = "0.1" }
-vecpool = { git = "https://github.com/MichaelDuPlessis/vecpool" }
+vecpool = "0.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ parallel = ["dep:pooled"]
 rand = "0.10.0"
 pooled = { version = "0.3", optional = true }
 evolve-derive = { path = "evolve-derive", version = "0.1" }
+vecpool = { git = "https://github.com/MichaelDuPlessis/vecpool" }
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,14 @@ parallel = ["dep:pooled"]
 rand = "0.10.0"
 pooled = { version = "0.3", optional = true }
 evolve-derive = { path = "evolve-derive", version = "0.1" }
+
+[dev-dependencies]
+criterion = { version = "0.8", features = ["html_reports"] }
+
+[[bench]]
+name = "genetic_operators"
+harness = false
+
+[[bench]]
+name = "algorithm"
+harness = false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # evolve
 
+[![Crates.io](https://img.shields.io/crates/v/evolve.svg)](https://crates.io/crates/evolve)
+[![Documentation](https://img.shields.io/docsrs/evolve)](https://docs.rs/evolve)
+[![License](https://img.shields.io/crates/l/evolve.svg)](LICENSE)
+
 A generic, composable genetic algorithm framework for Rust.
 
 > **Note:** This library is in rapid development. While breaking changes will be avoided where possible, there is no guarantee of API stability until 1.0.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A generic, composable genetic algorithm framework for Rust.
 - Composable combinators for structuring the flow of the algorithm
 - `Maximize` and `Minimize` fitness comparators out of the box
 - Closures work as fitness evaluators and comparators via blanket trait impls
-- No dependencies beyond `rand` (optional `pooled` for parallel execution)
+- Minimal dependencies: `rand` and `vecpool` (optional `pooled` for parallel execution)
 
 ## Quick Start
 
@@ -108,7 +108,7 @@ Enable the `parallel` feature to run operators across multiple threads:
 
 ```toml
 [dependencies]
-evolve = { version = "0.2.0", features = ["parallel"] }
+evolve = { version = "0.3", features = ["parallel"] }
 ```
 
 Parallel operators distribute work across a thread pool using the `pooled` crate:

--- a/benches/algorithm.rs
+++ b/benches/algorithm.rs
@@ -1,0 +1,76 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use evolve::{
+    algorithm::EvolutionaryAlgorithm,
+    collector::standard::Standard,
+    experiment::Experiment,
+    fitness::Maximize,
+    initialization::Random,
+    operators::sequential::{
+        combinator::{Combine, Fill, Pipeline},
+        crossover::SinglePoint,
+        mutation::RandomReset,
+        selection::TournamentSelection,
+    },
+    termination::MaxGenerations,
+};
+use rand::{SeedableRng, rngs::SmallRng};
+use std::num::NonZero;
+
+fn bench_ea_run(c: &mut Criterion) {
+    c.bench_function("ea_run_100pop_50gen", |b| {
+        b.iter(|| {
+            let mut ga = EvolutionaryAlgorithm::new(
+                Random::new(),
+                MaxGenerations::new(50),
+                |g: &[u8; 8]| g.iter().map(|&x| x as u32).sum::<u32>(),
+                Fill::from_population_size(Pipeline::new((
+                    Combine::new((
+                        TournamentSelection::new(NonZero::new(3).unwrap()),
+                        TournamentSelection::new(NonZero::new(3).unwrap()),
+                    )),
+                    SinglePoint::<u8>::new(),
+                    RandomReset::<u8>::new(),
+                ))),
+                NonZero::new(100).unwrap(),
+                SmallRng::seed_from_u64(42),
+                Maximize,
+            );
+            ga.run()
+        });
+    });
+}
+
+fn bench_experiment(c: &mut Criterion) {
+    c.bench_function("experiment_3_trials", |b| {
+        b.iter(|| {
+            let mut seed = 42u64;
+            Experiment::new(
+                move || {
+                    seed += 1;
+                    EvolutionaryAlgorithm::new(
+                        Random::new(),
+                        MaxGenerations::new(50),
+                        |g: &[u8; 8]| g.iter().map(|&x| x as u32).sum::<u32>(),
+                        Fill::from_population_size(Pipeline::new((
+                            Combine::new((
+                                TournamentSelection::new(NonZero::new(3).unwrap()),
+                                TournamentSelection::new(NonZero::new(3).unwrap()),
+                            )),
+                            SinglePoint::<u8>::new(),
+                            RandomReset::<u8>::new(),
+                        ))),
+                        NonZero::new(100).unwrap(),
+                        SmallRng::seed_from_u64(seed),
+                        Maximize,
+                    )
+                },
+                3,
+                Standard::default,
+            )
+            .run()
+        });
+    });
+}
+
+criterion_group!(benches, bench_ea_run, bench_experiment);
+criterion_main!(benches);

--- a/benches/algorithm.rs
+++ b/benches/algorithm.rs
@@ -3,18 +3,57 @@ use evolve::{
     algorithm::EvolutionaryAlgorithm,
     collector::standard::Standard,
     experiment::Experiment,
-    fitness::Maximize,
-    initialization::Random,
+    fitness::{GeFitness, Maximize},
+    grammar::Grammar,
+    initialization::{Random, RangedRandom},
     operators::sequential::{
-        combinator::{Combine, Fill, Pipeline},
+        combinator::{Combine, Fill, Pipeline, Weighted},
         crossover::SinglePoint,
-        mutation::RandomReset,
+        mutation::{RandomReset, deletion::SegmentDeletion, duplication::SegmentDuplication},
         selection::TournamentSelection,
     },
+    phenotype::{Event, PhenotypeBuilder},
     termination::MaxGenerations,
 };
 use rand::{SeedableRng, rngs::SmallRng};
 use std::num::NonZero;
+
+// --- GE support types ---
+
+struct TerminalCount(usize);
+
+impl TerminalCount {
+    fn run(&self, _: &()) -> usize {
+        self.0
+    }
+}
+
+#[derive(Default)]
+struct CountBuilder(usize);
+
+impl PhenotypeBuilder<&'static str> for CountBuilder {
+    type Output = TerminalCount;
+    fn push(&mut self, event: Event<&'static str>) {
+        if let Event::Terminal(_) = event {
+            self.0 += 1;
+        }
+    }
+    fn finish(self) -> TerminalCount {
+        TerminalCount(self.0)
+    }
+}
+
+fn arithmetic_grammar() -> Grammar<&'static str> {
+    Grammar::builder()
+        .rule("expr", &[&["expr", "op", "expr"], &["var"], &["const"]])
+        .rule("op", &[&["+"], &["-"], &["*"]])
+        .rule("var", &[&["x"], &["y"]])
+        .rule("const", &[&["1"], &["2"]])
+        .start("expr")
+        .build()
+}
+
+// --- GA benchmarks ---
 
 fn bench_ea_run(c: &mut Criterion) {
     c.bench_function("ea_run_100pop_50gen", |b| {
@@ -72,5 +111,83 @@ fn bench_experiment(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_ea_run, bench_experiment);
+// --- GE benchmarks ---
+
+fn bench_ge_run(c: &mut Criterion) {
+    c.bench_function("ge_run_100pop_50gen", |b| {
+        b.iter(|| {
+            let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
+                arithmetic_grammar(),
+                3,
+                |p: &TerminalCount| p.run(&()) as f64,
+                -1.0,
+            );
+            let mut ga = EvolutionaryAlgorithm::new(
+                RangedRandom::<u8>::new(5..20),
+                MaxGenerations::new(50),
+                fitness,
+                Fill::from_population_size(Pipeline::new((
+                    Combine::new((
+                        TournamentSelection::new(NonZero::new(3).unwrap()),
+                        TournamentSelection::new(NonZero::new(3).unwrap()),
+                    )),
+                    SinglePoint::<u8>::new(),
+                    Weighted::new((
+                        (RandomReset::<u8>::new(), NonZero::new(3u16).unwrap()),
+                        (SegmentDuplication::<u8>::new(0.2, 50), NonZero::new(1u16).unwrap()),
+                        (SegmentDeletion::<u8>::new(0.2, 3), NonZero::new(1u16).unwrap()),
+                    )),
+                ))),
+                NonZero::new(100).unwrap(),
+                SmallRng::seed_from_u64(42),
+                Maximize,
+            );
+            ga.run()
+        });
+    });
+}
+
+fn bench_ge_experiment(c: &mut Criterion) {
+    c.bench_function("ge_experiment_3_trials", |b| {
+        b.iter(|| {
+            let mut seed = 42u64;
+            Experiment::new(
+                move || {
+                    seed += 1;
+                    let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
+                        arithmetic_grammar(),
+                        3,
+                        |p: &TerminalCount| p.run(&()) as f64,
+                        -1.0,
+                    );
+                    EvolutionaryAlgorithm::new(
+                        RangedRandom::<u8>::new(5..20),
+                        MaxGenerations::new(50),
+                        fitness,
+                        Fill::from_population_size(Pipeline::new((
+                            Combine::new((
+                                TournamentSelection::new(NonZero::new(3).unwrap()),
+                                TournamentSelection::new(NonZero::new(3).unwrap()),
+                            )),
+                            SinglePoint::<u8>::new(),
+                            Weighted::new((
+                                (RandomReset::<u8>::new(), NonZero::new(3u16).unwrap()),
+                                (SegmentDuplication::<u8>::new(0.2, 50), NonZero::new(1u16).unwrap()),
+                                (SegmentDeletion::<u8>::new(0.2, 3), NonZero::new(1u16).unwrap()),
+                            )),
+                        ))),
+                        NonZero::new(100).unwrap(),
+                        SmallRng::seed_from_u64(seed),
+                        Maximize,
+                    )
+                },
+                3,
+                Standard::default,
+            )
+            .run()
+        });
+    });
+}
+
+criterion_group!(benches, bench_ea_run, bench_experiment, bench_ge_run, bench_ge_experiment);
 criterion_main!(benches);

--- a/benches/algorithm.rs
+++ b/benches/algorithm.rs
@@ -4,6 +4,7 @@ use evolve::{
     collector::standard::Standard,
     experiment::Experiment,
     fitness::{GeFitness, Maximize},
+    grammar,
     grammar::Grammar,
     initialization::{Random, RangedRandom},
     operators::sequential::{
@@ -51,6 +52,33 @@ fn arithmetic_grammar() -> Grammar<&'static str> {
         .rule("const", &[&["1"], &["2"]])
         .start("expr")
         .build()
+}
+
+// --- Macro grammar ---
+
+grammar! {
+    grammar MacroGrammar;
+    symbol Sym;
+    start Expr;
+    Expr => [Expr, Op, Expr] | [Var] | [Const];
+    Op => [Plus] | [Minus] | [Mul];
+    Var => [X] | [Y];
+    Const => [One] | [Two];
+}
+
+#[derive(Default)]
+struct MacroCountBuilder(usize);
+
+impl PhenotypeBuilder<Sym> for MacroCountBuilder {
+    type Output = TerminalCount;
+    fn push(&mut self, event: Event<Sym>) {
+        if let Event::Terminal(_) = event {
+            self.0 += 1;
+        }
+    }
+    fn finish(self) -> TerminalCount {
+        TerminalCount(self.0)
+    }
 }
 
 // --- GA benchmarks ---
@@ -111,7 +139,7 @@ fn bench_experiment(c: &mut Criterion) {
     });
 }
 
-// --- GE benchmarks ---
+// --- GE benchmarks (builder) ---
 
 fn bench_ge_run(c: &mut Criterion) {
     c.bench_function("ge_run_100pop_50gen", |b| {
@@ -134,8 +162,14 @@ fn bench_ge_run(c: &mut Criterion) {
                     SinglePoint::<u8>::new(),
                     Weighted::new((
                         (RandomReset::<u8>::new(), NonZero::new(3u16).unwrap()),
-                        (SegmentDuplication::<u8>::new(0.2, 50), NonZero::new(1u16).unwrap()),
-                        (SegmentDeletion::<u8>::new(0.2, 3), NonZero::new(1u16).unwrap()),
+                        (
+                            SegmentDuplication::<u8>::new(0.2, 50),
+                            NonZero::new(1u16).unwrap(),
+                        ),
+                        (
+                            SegmentDeletion::<u8>::new(0.2, 3),
+                            NonZero::new(1u16).unwrap(),
+                        ),
                     )),
                 ))),
                 NonZero::new(100).unwrap(),
@@ -172,8 +206,14 @@ fn bench_ge_experiment(c: &mut Criterion) {
                             SinglePoint::<u8>::new(),
                             Weighted::new((
                                 (RandomReset::<u8>::new(), NonZero::new(3u16).unwrap()),
-                                (SegmentDuplication::<u8>::new(0.2, 50), NonZero::new(1u16).unwrap()),
-                                (SegmentDeletion::<u8>::new(0.2, 3), NonZero::new(1u16).unwrap()),
+                                (
+                                    SegmentDuplication::<u8>::new(0.2, 50),
+                                    NonZero::new(1u16).unwrap(),
+                                ),
+                                (
+                                    SegmentDeletion::<u8>::new(0.2, 3),
+                                    NonZero::new(1u16).unwrap(),
+                                ),
                             )),
                         ))),
                         NonZero::new(100).unwrap(),
@@ -189,5 +229,104 @@ fn bench_ge_experiment(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_ea_run, bench_experiment, bench_ge_run, bench_ge_experiment);
+// --- GE benchmarks (macro) ---
+
+fn bench_ge_macro_run(c: &mut Criterion) {
+    c.bench_function("ge_macro_run_100pop_50gen", |b| {
+        b.iter(|| {
+            let fitness = GeFitness::<MacroGrammar, u8, f64, _, MacroCountBuilder>::new(
+                MacroGrammar,
+                3,
+                |p: &TerminalCount| p.run(&()) as f64,
+                -1.0,
+            );
+            let mut ga = EvolutionaryAlgorithm::new(
+                RangedRandom::<u8>::new(5..20),
+                MaxGenerations::new(50),
+                fitness,
+                Fill::from_population_size(Pipeline::new((
+                    Combine::new((
+                        TournamentSelection::new(NonZero::new(3).unwrap()),
+                        TournamentSelection::new(NonZero::new(3).unwrap()),
+                    )),
+                    SinglePoint::<u8>::new(),
+                    Weighted::new((
+                        (RandomReset::<u8>::new(), NonZero::new(3u16).unwrap()),
+                        (
+                            SegmentDuplication::<u8>::new(0.2, 50),
+                            NonZero::new(1u16).unwrap(),
+                        ),
+                        (
+                            SegmentDeletion::<u8>::new(0.2, 3),
+                            NonZero::new(1u16).unwrap(),
+                        ),
+                    )),
+                ))),
+                NonZero::new(100).unwrap(),
+                SmallRng::seed_from_u64(42),
+                Maximize,
+            );
+            ga.run()
+        });
+    });
+}
+
+fn bench_ge_macro_experiment(c: &mut Criterion) {
+    c.bench_function("ge_macro_experiment_3_trials", |b| {
+        b.iter(|| {
+            let mut seed = 42u64;
+            Experiment::new(
+                move || {
+                    seed += 1;
+                    let fitness =
+                        GeFitness::<MacroGrammar, u8, f64, _, MacroCountBuilder>::new(
+                            MacroGrammar,
+                            3,
+                            |p: &TerminalCount| p.run(&()) as f64,
+                            -1.0,
+                        );
+                    EvolutionaryAlgorithm::new(
+                        RangedRandom::<u8>::new(5..20),
+                        MaxGenerations::new(50),
+                        fitness,
+                        Fill::from_population_size(Pipeline::new((
+                            Combine::new((
+                                TournamentSelection::new(NonZero::new(3).unwrap()),
+                                TournamentSelection::new(NonZero::new(3).unwrap()),
+                            )),
+                            SinglePoint::<u8>::new(),
+                            Weighted::new((
+                                (RandomReset::<u8>::new(), NonZero::new(3u16).unwrap()),
+                                (
+                                    SegmentDuplication::<u8>::new(0.2, 50),
+                                    NonZero::new(1u16).unwrap(),
+                                ),
+                                (
+                                    SegmentDeletion::<u8>::new(0.2, 3),
+                                    NonZero::new(1u16).unwrap(),
+                                ),
+                            )),
+                        ))),
+                        NonZero::new(100).unwrap(),
+                        SmallRng::seed_from_u64(seed),
+                        Maximize,
+                    )
+                },
+                3,
+                Standard::default,
+            )
+            .run()
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_ea_run,
+    bench_experiment,
+    bench_ge_run,
+    bench_ge_experiment,
+    bench_ge_macro_run,
+    bench_ge_macro_experiment,
+);
 criterion_main!(benches);

--- a/benches/genetic_operators.rs
+++ b/benches/genetic_operators.rs
@@ -1,0 +1,313 @@
+use criterion::{Criterion, criterion_group, criterion_main};
+use evolve::{
+    core::{context::Context, individual::Individual, population::Population, state::State},
+    fitness::{GeFitness, Maximize},
+    grammar::Grammar,
+    initialization::{Initializer, Random, RangedRandom},
+    operators::{
+        GeneticOperator,
+        sequential::{
+            combinator::{Combine, Fill, Pipeline},
+            crossover::SinglePoint,
+            mutation::{deletion::SegmentDeletion, duplication::SegmentDuplication, RandomReset},
+            selection::TournamentSelection,
+        },
+    },
+    phenotype::{Event, PhenotypeBuilder},
+};
+use rand::{SeedableRng, rngs::SmallRng};
+use std::num::NonZero;
+
+fn make_population_array(rng: &mut SmallRng, size: usize) -> Population<[u8; 8], u32> {
+    use evolve::random::Randomizable;
+    (0..size)
+        .map(|_| Individual::new(<[u8; 8]>::random(rng)))
+        .collect()
+}
+
+fn make_population_vec(rng: &mut SmallRng, size: usize) -> Population<Vec<u8>, u32> {
+    use evolve::random::Randomizable;
+    use rand::RngExt;
+    (0..size)
+        .map(|_| {
+            let len = rng.random_range(50..200);
+            Individual::new((0..len).map(|_| u8::random(rng)).collect())
+        })
+        .collect()
+}
+
+fn fitness_array(g: &[u8; 8]) -> u32 {
+    g.iter().map(|&x| x as u32).sum()
+}
+
+fn fitness_vec(g: &Vec<u8>) -> u32 {
+    g.iter().map(|&x| x as u32).sum()
+}
+
+fn bench_crossover(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crossover");
+
+    group.bench_function("single_point_array", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_array(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        let op = SinglePoint::<u8>::new();
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.bench_function("single_point_vec", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_vec(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_vec as fn(&Vec<u8>) -> u32;
+        let op = SinglePoint::<u8>::new();
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_mutation(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mutation");
+
+    group.bench_function("random_reset_array", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_array(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        let op = RandomReset::<u8>::new();
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.bench_function("segment_duplication_vec", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_vec(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_vec as fn(&Vec<u8>) -> u32;
+        let op = SegmentDuplication::<u8>::new(0.25, 400);
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.bench_function("segment_deletion_vec", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_vec(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_vec as fn(&Vec<u8>) -> u32;
+        let op = SegmentDeletion::<u8>::new(0.25, 10);
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_selection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("selection");
+
+    group.bench_function("tournament_size_3", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_array(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        let op = TournamentSelection::new(NonZero::new(3).unwrap());
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_initialization(c: &mut Criterion) {
+    let mut group = c.benchmark_group("initialization");
+
+    group.bench_function("random_array_100", |b| {
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            Random::new().initialize(NonZero::new(100).unwrap(), &mut ctx)
+        });
+    });
+
+    group.bench_function("ranged_random_vec_100", |b| {
+        let fe = fitness_vec as fn(&Vec<u8>) -> u32;
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            RangedRandom::<u8>::new(50..200).initialize(NonZero::new(100).unwrap(), &mut ctx)
+        });
+    });
+
+    group.finish();
+}
+
+fn bench_combinators(c: &mut Criterion) {
+    let mut group = c.benchmark_group("combinators");
+
+    group.bench_function("fill", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_array(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        let op = Fill::from_population_size(Pipeline::new((
+            Combine::new((
+                TournamentSelection::new(NonZero::new(3).unwrap()),
+                TournamentSelection::new(NonZero::new(3).unwrap()),
+            )),
+            SinglePoint::<u8>::new(),
+            RandomReset::<u8>::new(),
+        )));
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.bench_function("pipeline", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_array(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        let op = Pipeline::new((
+            TournamentSelection::new(NonZero::new(3).unwrap()),
+            SinglePoint::<u8>::new(),
+            RandomReset::<u8>::new(),
+        ));
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.finish();
+}
+
+// GE mapping benchmark
+#[derive(Debug)]
+struct Expr(f64);
+
+#[derive(Default)]
+struct ExprBuilder(Vec<&'static str>);
+
+impl PhenotypeBuilder<&'static str> for ExprBuilder {
+    type Output = Expr;
+    fn push(&mut self, event: Event<&'static str>) {
+        if let Event::Terminal(t) = event {
+            self.0.push(t);
+        }
+    }
+    fn finish(self) -> Expr {
+        // Simple evaluation: count terminals as a proxy
+        Expr(self.0.len() as f64)
+    }
+}
+
+fn bench_ge_mapping(c: &mut Criterion) {
+    let grammar = Grammar::builder()
+        .rule("expr", &[&["expr", "op", "expr"], &["num"]])
+        .rule("op", &[&["+"], &["-"], &["*"]])
+        .rule("num", &[&["1"], &["2"], &["3"]])
+        .start("expr")
+        .build();
+
+    let ge = GeFitness::<_, u8, f64, _, ExprBuilder>::new(
+        grammar,
+        3,
+        |p: &Expr| p.0,
+        0.0,
+    );
+
+    c.bench_function("ge_mapping", |b| {
+        let genome: Vec<u8> = vec![0, 1, 0, 2, 1, 0, 2, 1, 0, 1, 2, 0, 1, 2, 0];
+        b.iter(|| ge.phenotype(&genome));
+    });
+}
+
+#[cfg(feature = "parallel")]
+fn bench_parallel(c: &mut Criterion) {
+    use evolve::operators::parallel::{
+        combinator::Fill as ParFill, mutation::RandomReset as ParRandomReset,
+    };
+
+    let mut group = c.benchmark_group("parallel");
+
+    group.bench_function("fill", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_array(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        let runtime = pooled::Runtime::new(4);
+        let op = ParFill::new(RandomReset::<u8>::new(), 100);
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize, &runtime);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.bench_function("random_reset", |b| {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let pop = make_population_array(&mut rng, 100);
+        let state = State::new(pop, 0);
+        let fe = fitness_array as fn(&[u8; 8]) -> u32;
+        let runtime = pooled::Runtime::new(4);
+        let op = ParRandomReset::<u8>::new();
+        b.iter(|| {
+            let mut rng = SmallRng::seed_from_u64(42);
+            let mut ctx = Context::new(&fe, &mut rng, &Maximize, &runtime);
+            op.apply(&state, &mut ctx)
+        });
+    });
+
+    group.finish();
+}
+
+#[cfg(not(feature = "parallel"))]
+criterion_group!(
+    benches,
+    bench_crossover,
+    bench_mutation,
+    bench_selection,
+    bench_initialization,
+    bench_combinators,
+    bench_ge_mapping,
+);
+
+#[cfg(feature = "parallel")]
+criterion_group!(
+    benches,
+    bench_crossover,
+    bench_mutation,
+    bench_selection,
+    bench_initialization,
+    bench_combinators,
+    bench_ge_mapping,
+    bench_parallel,
+);
+
+criterion_main!(benches);

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -105,7 +105,7 @@ where
         }
     }
 
-    /// Runs the algorithm until the termination condition is met and returns a [`RunResult`](collector::standard::RunResult).
+    /// Runs the algorithm until the termination condition is met and returns a [`RunResult`](crate::collector::standard::RunResult).
     pub fn run(&mut self) -> standard::RunResult<G, F>
     where
         F: Clone + PartialOrd,

--- a/src/core/individual.rs
+++ b/src/core/individual.rs
@@ -61,4 +61,19 @@ impl<G, F> Individual<G, F> {
         self.fitness
             .get_or_init(|| fitness_evaluator.evaluate(&self.genome))
     }
+
+    /// Creates a new `Individual` with a clone of this individual's genome
+    /// and an unevaluated fitness cell.
+    ///
+    /// Use this when the cloned individual will have its genome modified
+    /// (e.g., by crossover or mutation), making the original fitness irrelevant.
+    pub fn clone_genome_only(&self) -> Self
+    where
+        G: Clone,
+    {
+        Self {
+            genome: self.genome.clone(),
+            fitness: FitnessCell::new(),
+        }
+    }
 }

--- a/src/core/individual.rs
+++ b/src/core/individual.rs
@@ -76,4 +76,12 @@ impl<G, F> Individual<G, F> {
             fitness: FitnessCell::new(),
         }
     }
+
+    /// Consumes this individual, applies a function to its genome, and returns
+    /// a new individual with the modified genome and unevaluated fitness.
+    pub fn mutate_genome(self, f: impl FnOnce(&mut G)) -> Self {
+        let mut genome = self.genome;
+        f(&mut genome);
+        Self::new(genome)
+    }
 }

--- a/src/core/offspring.rs
+++ b/src/core/offspring.rs
@@ -30,7 +30,11 @@ impl<G, F> Offspring<G, F> {
     /// Converts this `Offspring` into a [`Population`].
     pub fn into_population(self) -> Population<G, F> {
         match self {
-            Offspring::Single(individual) => Population::from_individuals(vec![individual]),
+            Offspring::Single(individual) => {
+                let mut p = Population::new();
+                p.add(individual);
+                p
+            }
             Offspring::Multiple(population) => population,
         }
     }

--- a/src/core/population.rs
+++ b/src/core/population.rs
@@ -1,4 +1,5 @@
 use rand::{Rng, seq::IndexedRandom};
+use vecpool::PoolVec;
 
 use crate::{
     core::{individual::Individual, offspring::Offspring},
@@ -25,29 +26,31 @@ use std::slice::ChunksExact;
 /// assert_eq!(pop.len(), 2);
 /// assert_eq!(*pop.best(&fe, &Maximize).fitness(&fe), 20);
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct Population<G, F> {
-    individuals: Vec<Individual<G, F>>,
+    individuals: PoolVec<Individual<G, F>>,
 }
 
 impl<G, F> Population<G, F> {
     /// Create a new empty population.
     pub fn new() -> Self {
         Self {
-            individuals: Vec::new(),
+            individuals: PoolVec::new(),
         }
     }
 
     /// Create an empty population with a certain capacity.
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
-            individuals: Vec::with_capacity(capacity),
+            individuals: vecpool::with_capacity(capacity),
         }
     }
 
     /// Create a new population from a `Vec` of `Individuals`.
     pub fn from_individuals(individuals: Vec<Individual<G, F>>) -> Self {
-        Self { individuals }
+        Self {
+            individuals: PoolVec::from(individuals),
+        }
     }
 
     /// Extend a `Population` with another `Population` or a list of `Individuals`.
@@ -92,7 +95,7 @@ impl<G, F> Population<G, F> {
 
     /// Consumes the population and returns the inner Vec.
     pub fn into_vec(self) -> Vec<Individual<G, F>> {
-        self.individuals
+        self.individuals.into_vec()
     }
 
     /// Choose a random individual from the population.
@@ -127,7 +130,7 @@ impl<G, F> Population<G, F> {
 
     /// Merges another `Population` into one this one.
     pub fn merge(&mut self, population: Population<G, F>) {
-        self.individuals.extend(population.individuals);
+        self.individuals.extend(population.individuals.into_vec());
     }
 
     /// Add an `Offspring` to the population.
@@ -194,5 +197,13 @@ impl<G, F> FromIterator<Individual<G, F>> for Population<G, F> {
 impl<G, F> Default for Population<G, F> {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl<G: Clone, F: Clone> Clone for Population<G, F> {
+    fn clone(&self) -> Self {
+        Self {
+            individuals: self.individuals.iter().cloned().collect(),
+        }
     }
 }

--- a/src/grammar/mapper.rs
+++ b/src/grammar/mapper.rs
@@ -2,6 +2,7 @@
 
 use crate::grammar::grammar_def::GrammarDef;
 use crate::phenotype::{Event, PhenotypeBuilder};
+use vecpool::PoolVec;
 
 /// Trait bound for codon types. Converts a codon to a choice index.
 pub trait Codon: Clone + Copy {
@@ -45,8 +46,9 @@ pub(crate) fn map<G: GrammarDef, C: Codon, B: PhenotypeBuilder<G::Terminal>>(
     max_wraps: usize,
     mut builder: B,
 ) -> Option<B::Output> {
-    let mut stack: Vec<G::Symbol> = vec![grammar.start()];
-    let mut end_rule_stack: Vec<usize> = Vec::new();
+    let mut stack: PoolVec<G::Symbol> = PoolVec::new();
+    stack.push(grammar.start());
+    let mut end_rule_stack: PoolVec<usize> = PoolVec::new();
     let mut codon_idx: usize = 0;
 
     while let Some(symbol) = stack.pop() {

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -11,31 +11,91 @@ pub mod sequential;
 
 /// The core trait for all genetic operators (selection, crossover, mutation, combinators, etc.).
 ///
-/// An operator receives the current [`State`] and a [`Context`] and produces an [`Offspring`].
+/// An operator receives the current [`State`] (population + generation) and a
+/// [`Context`] (fitness evaluator + RNG + comparator) and produces [`Offspring`].
+///
+/// # Two methods
+///
+/// - [`apply`](Self::apply) — receives a borrowed state. Use this when the caller
+///   retains ownership of the population (e.g., [`Fill`](crate::operators::sequential::combinator::Fill)
+///   calls the same operator repeatedly against the same population).
+///
+/// - [`transform`](Self::transform) — receives an owned state. Used by
+///   [`Pipeline`](crate::operators::sequential::combinator::Pipeline) to pass
+///   data between chained operators. Operators that can modify individuals in place
+///   (e.g., mutation) should override this to avoid unnecessary cloning.
+///
+/// Most operators only need to implement [`apply`](Self::apply). The default
+/// [`transform`](Self::transform) delegates to it.
 ///
 /// # Examples
 ///
+/// A simple operator that only implements `apply`:
+///
 /// ```
 /// use evolve::core::{context::Context, offspring::Offspring, state::State};
+/// use evolve::core::individual::Individual;
 /// use evolve::operators::GeneticOperator;
+/// use evolve::fitness::FitnessEvaluator;
+/// use rand::{Rng, RngExt};
 ///
-/// struct MyOperator;
+/// /// Replaces every individual's genome with a random value.
+/// struct Randomize;
 ///
-/// impl<G, F, Fe, R, C> GeneticOperator<G, F, Fe, R, C> for MyOperator {
-///     fn apply(&self, state: &State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
-///         todo!()
+/// impl<F, R: Rng, Fe: FitnessEvaluator<u32, F>, C> GeneticOperator<u32, F, Fe, R, C> for Randomize {
+///     fn apply(&self, state: &State<u32, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<u32, F> {
+///         let ind = Individual::new(ctx.rng().random::<u32>());
+///         Offspring::Single(ind)
+///     }
+/// }
+/// ```
+///
+/// An operator that overrides `transform` for in-place mutation:
+///
+/// ```
+/// use evolve::core::{context::Context, offspring::Offspring, population::Population, state::State};
+/// use evolve::core::individual::Individual;
+/// use evolve::operators::GeneticOperator;
+/// use evolve::fitness::FitnessEvaluator;
+/// use rand::Rng;
+///
+/// /// Doubles every genome value in place.
+/// struct DoubleGenome;
+///
+/// impl<F, R: Rng, Fe: FitnessEvaluator<u32, F>, C> GeneticOperator<u32, F, Fe, R, C> for DoubleGenome {
+///     fn apply(&self, state: &State<u32, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<u32, F> {
+///         // Fallback: clone and modify
+///         let pop: Population<u32, F> = state.population().iter()
+///             .map(|ind| Individual::new(ind.genome() * 2))
+///             .collect();
+///         Offspring::Multiple(pop)
+///     }
+///
+///     fn transform(&self, state: State<u32, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<u32, F> {
+///         // Optimized: modify in place without cloning
+///         let pop: Population<u32, F> = state.into_population().into_iter()
+///             .map(|ind| ind.mutate_genome(|g| *g *= 2))
+///             .collect();
+///         Offspring::Multiple(pop)
 ///     }
 /// }
 /// ```
 pub trait GeneticOperator<G, F, Fe, R, C> {
-    /// Applies this operator to the current state and returns the resulting offspring.
+    /// Applies this operator to a borrowed state and returns the resulting offspring.
+    ///
+    /// The state is immutable — the operator reads the population but cannot
+    /// modify it. This is the primary method to implement for any operator.
     fn apply(&self, state: &State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F>;
 
     /// Applies this operator to an owned state, allowing in-place modification.
     ///
-    /// The default implementation borrows the state and delegates to [`apply`](Self::apply).
-    /// Operators that can work in-place (e.g., mutation) may override this to
-    /// avoid cloning genomes.
+    /// Called by [`Pipeline`](crate::operators::sequential::combinator::Pipeline)
+    /// when chaining operators. Since the state is owned, operators can
+    /// destructure it and modify individuals directly without cloning.
+    ///
+    /// The default implementation borrows the owned state and delegates to
+    /// [`apply`](Self::apply). Override this in operators (like mutation) that
+    /// can transform individuals in place for better performance.
     fn transform(&self, state: State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
         self.apply(&state, ctx)
     }

--- a/src/operators.rs
+++ b/src/operators.rs
@@ -30,6 +30,15 @@ pub mod sequential;
 pub trait GeneticOperator<G, F, Fe, R, C> {
     /// Applies this operator to the current state and returns the resulting offspring.
     fn apply(&self, state: &State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F>;
+
+    /// Applies this operator to an owned state, allowing in-place modification.
+    ///
+    /// The default implementation borrows the state and delegates to [`apply`](Self::apply).
+    /// Operators that can work in-place (e.g., mutation) may override this to
+    /// avoid cloning genomes.
+    fn transform(&self, state: State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
+        self.apply(&state, ctx)
+    }
 }
 
 impl<G, F, Fe, R, C, O> GeneticOperator<G, F, Fe, R, C> for &O
@@ -39,6 +48,10 @@ where
     fn apply(&self, state: &State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
         (*self).apply(state, ctx)
     }
+
+    fn transform(&self, state: State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
+        (*self).transform(state, ctx)
+    }
 }
 
 impl<G, F, Fe, R, C, O> GeneticOperator<G, F, Fe, R, C> for &mut O
@@ -47,5 +60,9 @@ where
 {
     fn apply(&self, state: &State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
         (**self).apply(state, ctx)
+    }
+
+    fn transform(&self, state: State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
+        (**self).transform(state, ctx)
     }
 }

--- a/src/operators/common.rs
+++ b/src/operators/common.rs
@@ -34,8 +34,13 @@ pub(crate) fn single_point_crossover_vec<T: Clone>(
     let point1 = ((ratio * p1.len() as f64) as usize).clamp(1, p1.len() - 1);
     let point2 = ((ratio * p2.len() as f64) as usize).clamp(1, p2.len() - 1);
 
-    let child1 = [&p1[..point1], &p2[point2..]].concat();
-    let child2 = [&p2[..point2], &p1[point1..]].concat();
+    let mut child1 = Vec::with_capacity(point1 + p2.len() - point2);
+    child1.extend_from_slice(&p1[..point1]);
+    child1.extend_from_slice(&p2[point2..]);
+
+    let mut child2 = Vec::with_capacity(point2 + p1.len() - point1);
+    child2.extend_from_slice(&p2[..point2]);
+    child2.extend_from_slice(&p1[point1..]);
 
     (child1, child2)
 }

--- a/src/operators/common.rs
+++ b/src/operators/common.rs
@@ -27,22 +27,26 @@ pub(crate) fn single_point_crossover_vec<T: Clone>(
     rng: &mut impl Rng,
 ) -> (Vec<T>, Vec<T>) {
     if p1.len() < 2 || p2.len() < 2 {
-        return (p1.to_vec(), p2.to_vec());
+        let mut c1: vecpool::PoolVec<T> = vecpool::with_capacity(p1.len());
+        c1.extend_from_slice(p1);
+        let mut c2: vecpool::PoolVec<T> = vecpool::with_capacity(p2.len());
+        c2.extend_from_slice(p2);
+        return (c1.into_vec(), c2.into_vec());
     }
 
     let ratio: f64 = rng.random();
     let point1 = ((ratio * p1.len() as f64) as usize).clamp(1, p1.len() - 1);
     let point2 = ((ratio * p2.len() as f64) as usize).clamp(1, p2.len() - 1);
 
-    let mut child1 = Vec::with_capacity(point1 + p2.len() - point2);
+    let mut child1: vecpool::PoolVec<T> = vecpool::with_capacity(point1 + p2.len() - point2);
     child1.extend_from_slice(&p1[..point1]);
     child1.extend_from_slice(&p2[point2..]);
 
-    let mut child2 = Vec::with_capacity(point2 + p1.len() - point1);
+    let mut child2: vecpool::PoolVec<T> = vecpool::with_capacity(point2 + p1.len() - point1);
     child2.extend_from_slice(&p2[..point2]);
     child2.extend_from_slice(&p1[point1..]);
 
-    (child1, child2)
+    (child1.into_vec(), child2.into_vec())
 }
 
 /// Mutates a genome by replacing a random gene with a new random value.

--- a/src/operators/parallel/combinator/combine.rs
+++ b/src/operators/parallel/combinator/combine.rs
@@ -37,7 +37,7 @@ macro_rules! impl_parallel_combine {
         {
             fn apply(&self, state: &State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
                 let ops: &[O] = &self.operators;
-                let inputs: Vec<(u64, usize)> = (0..ops.len())
+                let inputs: vecpool::PoolVec<(u64, usize)> = (0..ops.len())
                     .map(|i| (ctx.rng().random::<u64>(), i))
                     .collect();
 

--- a/src/operators/parallel/combinator/fill.rs
+++ b/src/operators/parallel/combinator/fill.rs
@@ -40,7 +40,7 @@ where
         let chunk_size = self.target_size / num_chunks;
         let extra = self.target_size % num_chunks;
 
-        let inputs: Vec<(u64, usize)> = (0..num_chunks)
+        let inputs: vecpool::PoolVec<(u64, usize)> = (0..num_chunks)
             .map(|i| {
                 let size = chunk_size + if i < extra { 1 } else { 0 };
                 (ctx.rng().random::<u64>(), size)

--- a/src/operators/parallel/combinator/repeat.rs
+++ b/src/operators/parallel/combinator/repeat.rs
@@ -36,7 +36,7 @@ where
         let chunk_size = self.n / num_chunks;
         let extra = self.n % num_chunks;
 
-        let inputs: Vec<(u64, usize)> = (0..num_chunks)
+        let inputs: vecpool::PoolVec<(u64, usize)> = (0..num_chunks)
             .map(|i| {
                 let reps = chunk_size + if i < extra { 1 } else { 0 };
                 (ctx.rng().random::<u64>(), reps)

--- a/src/operators/parallel/crossover.rs
+++ b/src/operators/parallel/crossover.rs
@@ -46,7 +46,7 @@ where
 {
     fn apply(&self, state: &State<[T; N], F>, ctx: &mut Context<Fe, R, C>) -> Offspring<[T; N], F> {
         let individuals = state.population().as_slice();
-        let inputs: Vec<(u64, usize)> = individuals
+        let inputs: vecpool::PoolVec<(u64, usize)> = individuals
             .chunks_exact(2)
             .enumerate()
             .map(|(i, _)| (ctx.rng().random::<u64>(), i))
@@ -84,7 +84,7 @@ where
 {
     fn apply(&self, state: &State<Vec<T>, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<Vec<T>, F> {
         let individuals = state.population().as_slice();
-        let inputs: Vec<(u64, usize)> = individuals
+        let inputs: vecpool::PoolVec<(u64, usize)> = individuals
             .chunks_exact(2)
             .enumerate()
             .map(|(i, _)| (ctx.rng().random::<u64>(), i))

--- a/src/operators/parallel/mutation.rs
+++ b/src/operators/parallel/mutation.rs
@@ -52,7 +52,7 @@ where
 {
     fn apply(&self, state: &State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
         let individuals = state.population().as_slice();
-        let inputs: Vec<(u64, usize)> = (0..individuals.len())
+        let inputs: vecpool::PoolVec<(u64, usize)> = (0..individuals.len())
             .map(|i| (ctx.rng().random::<u64>(), i))
             .collect();
 

--- a/src/operators/sequential/combinator/pipeline.rs
+++ b/src/operators/sequential/combinator/pipeline.rs
@@ -82,7 +82,7 @@ macro_rules! impl_genetic_pipeline {
                 $(
                     let next_state = state.with_population(current_population);
 
-                    current_population = match $rest.apply(&next_state, ctx) {
+                    current_population = match $rest.transform(next_state, ctx) {
                         Offspring::Single(ind) => {
                             let mut p = Population::new();
                             p.add(ind);
@@ -114,8 +114,8 @@ where
 
         for operator in &self.0[1..] {
             let population = offspring.into_population();
-            let state = state.with_population(population);
-            offspring = operator.apply(&state, ctx);
+            let owned_state = state.with_population(population);
+            offspring = operator.transform(owned_state, ctx);
         }
 
         offspring
@@ -131,8 +131,8 @@ where
 
         for operator in &self.0[1..] {
             let population = offspring.into_population();
-            let state = state.with_population(population);
-            offspring = operator.apply(&state, ctx);
+            let owned_state = state.with_population(population);
+            offspring = operator.transform(owned_state, ctx);
         }
 
         offspring
@@ -148,8 +148,8 @@ where
 
         for operator in &self.0[1..] {
             let population = offspring.into_population();
-            let state = state.with_population(population);
-            offspring = operator.apply(&state, ctx);
+            let owned_state = state.with_population(population);
+            offspring = operator.transform(owned_state, ctx);
         }
 
         offspring

--- a/src/operators/sequential/mutation/deletion.rs
+++ b/src/operators/sequential/mutation/deletion.rs
@@ -64,4 +64,24 @@ where
 
         Offspring::Multiple(population)
     }
+
+    fn transform(&self, state: State<Vec<T>, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<Vec<T>, F> {
+        let population = state.into_population();
+        let mutated: Vec<_> = population.into_iter()
+            .map(|ind| ind.mutate_genome(|genome| {
+                let len = genome.len();
+                let max_by_fraction = (len as f64 * self.max_segment_fraction).floor() as usize;
+                let max_by_min_len = len.saturating_sub(self.min_genome_len);
+                let max_deletable = max_by_fraction.min(max_by_min_len);
+                if max_deletable < 1 {
+                    return;
+                }
+                let seg_len = ctx.rng().random_range(1..=max_deletable);
+                let start = ctx.rng().random_range(0..=(len - seg_len));
+                genome.drain(start..start + seg_len);
+            }))
+            .collect();
+
+        Offspring::Multiple(Population::from_individuals(mutated))
+    }
 }

--- a/src/operators/sequential/mutation/deletion.rs
+++ b/src/operators/sequential/mutation/deletion.rs
@@ -55,10 +55,10 @@ where
             } else {
                 let seg_len = ctx.rng().random_range(1..=max_deletable);
                 let start = ctx.rng().random_range(0..=(len - seg_len));
-                let mut new_genome = Vec::with_capacity(len - seg_len);
+                let mut new_genome: vecpool::PoolVec<T> = vecpool::with_capacity(len - seg_len);
                 new_genome.extend_from_slice(&genome[..start]);
                 new_genome.extend_from_slice(&genome[start + seg_len..]);
-                population.add(Individual::new(new_genome));
+                population.add(Individual::new(new_genome.into_vec()));
             }
         }
 
@@ -66,8 +66,7 @@ where
     }
 
     fn transform(&self, state: State<Vec<T>, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<Vec<T>, F> {
-        let population = state.into_population();
-        let mutated: Vec<_> = population.into_iter()
+        let population: Population<Vec<T>, F> = state.into_population().into_iter()
             .map(|ind| ind.mutate_genome(|genome| {
                 let len = genome.len();
                 let max_by_fraction = (len as f64 * self.max_segment_fraction).floor() as usize;
@@ -82,6 +81,6 @@ where
             }))
             .collect();
 
-        Offspring::Multiple(Population::from_individuals(mutated))
+        Offspring::Multiple(population)
     }
 }

--- a/src/operators/sequential/mutation/duplication.rs
+++ b/src/operators/sequential/mutation/duplication.rs
@@ -59,11 +59,11 @@ where
                 population.add(Individual::new(genome.clone()));
             } else {
                 let start = ctx.rng().random_range(0..=(len - seg_len));
-                let mut new_genome = Vec::with_capacity(len + seg_len);
+                let mut new_genome: vecpool::PoolVec<T> = vecpool::with_capacity(len + seg_len);
                 new_genome.extend_from_slice(&genome[..start + seg_len]);
                 new_genome.extend_from_slice(&genome[start..start + seg_len]);
                 new_genome.extend_from_slice(&genome[start + seg_len..]);
-                population.add(Individual::new(new_genome));
+                population.add(Individual::new(new_genome.into_vec()));
             }
         }
 
@@ -71,8 +71,7 @@ where
     }
 
     fn transform(&self, state: State<Vec<T>, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<Vec<T>, F> {
-        let population = state.into_population();
-        let mutated: Vec<_> = population.into_iter()
+        let population: Population<Vec<T>, F> = state.into_population().into_iter()
             .map(|ind| ind.mutate_genome(|genome| {
                 let len = genome.len();
                 if len == 0 {
@@ -84,11 +83,12 @@ where
                     return;
                 }
                 let start = ctx.rng().random_range(0..=(len - seg_len));
-                let segment: Vec<T> = genome[start..start + seg_len].to_vec();
-                genome.splice(start + seg_len..start + seg_len, segment);
+                let mut segment: vecpool::PoolVec<T> = vecpool::with_capacity(seg_len);
+                segment.extend_from_slice(&genome[start..start + seg_len]);
+                genome.splice(start + seg_len..start + seg_len, segment.into_vec());
             }))
             .collect();
 
-        Offspring::Multiple(Population::from_individuals(mutated))
+        Offspring::Multiple(population)
     }
 }

--- a/src/operators/sequential/mutation/duplication.rs
+++ b/src/operators/sequential/mutation/duplication.rs
@@ -69,4 +69,26 @@ where
 
         Offspring::Multiple(population)
     }
+
+    fn transform(&self, state: State<Vec<T>, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<Vec<T>, F> {
+        let population = state.into_population();
+        let mutated: Vec<_> = population.into_iter()
+            .map(|ind| ind.mutate_genome(|genome| {
+                let len = genome.len();
+                if len == 0 {
+                    return;
+                }
+                let max_seg = ((len as f64 * self.max_segment_fraction).floor() as usize).max(1);
+                let seg_len = ctx.rng().random_range(1..=max_seg);
+                if len + seg_len > self.max_genome_len {
+                    return;
+                }
+                let start = ctx.rng().random_range(0..=(len - seg_len));
+                let segment: Vec<T> = genome[start..start + seg_len].to_vec();
+                genome.splice(start + seg_len..start + seg_len, segment);
+            }))
+            .collect();
+
+        Offspring::Multiple(Population::from_individuals(mutated))
+    }
 }

--- a/src/operators/sequential/mutation/mod.rs
+++ b/src/operators/sequential/mutation/mod.rs
@@ -75,8 +75,7 @@ where
     }
 
     fn transform(&self, state: State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
-        let population = state.into_population();
-        let mutated: Vec<_> = population.into_iter()
+        let population: Population<G, F> = state.into_population().into_iter()
             .map(|ind| ind.mutate_genome(|genome| {
                 let genes = genome.as_mut();
                 let gene_index = ctx.rng().random_range(0..genes.len());
@@ -84,10 +83,10 @@ where
             }))
             .collect();
 
-        if mutated.len() == 1 {
-            Offspring::Single(mutated.into_iter().next().unwrap())
+        if population.len() == 1 {
+            Offspring::Single(population.into_iter().next().unwrap())
         } else {
-            Offspring::Multiple(Population::from_individuals(mutated))
+            Offspring::Multiple(population)
         }
     }
 }

--- a/src/operators/sequential/mutation/mod.rs
+++ b/src/operators/sequential/mutation/mod.rs
@@ -12,7 +12,7 @@ use crate::{
     operators::{GeneticOperator, common::random_reset_mutate},
     random::Randomizable,
 };
-use rand::Rng;
+use rand::{Rng, RngExt};
 use std::marker::PhantomData;
 
 /// This is a helper trait to get the code to compile since a T may one day implement AsMut<[T]>
@@ -71,6 +71,23 @@ where
             }
 
             Offspring::Multiple(population)
+        }
+    }
+
+    fn transform(&self, state: State<G, F>, ctx: &mut Context<Fe, R, C>) -> Offspring<G, F> {
+        let population = state.into_population();
+        let mutated: Vec<_> = population.into_iter()
+            .map(|ind| ind.mutate_genome(|genome| {
+                let genes = genome.as_mut();
+                let gene_index = ctx.rng().random_range(0..genes.len());
+                genes[gene_index] = T::random(ctx.rng());
+            }))
+            .collect();
+
+        if mutated.len() == 1 {
+            Offspring::Single(mutated.into_iter().next().unwrap())
+        } else {
+            Offspring::Multiple(Population::from_individuals(mutated))
         }
     }
 }

--- a/src/operators/sequential/selection/elitism.rs
+++ b/src/operators/sequential/selection/elitism.rs
@@ -60,7 +60,7 @@ where
                     .clone(),
             )
         } else {
-            let mut refs: Vec<_> = state.population().iter().collect();
+            let mut refs: vecpool::PoolVec<_> = state.population().iter().collect();
             refs.select_nth_unstable_by(self.amount - 1, |a, b| {
                 if ctx.comparator().is_better(
                     a.fitness(ctx.fitness_evaluator()),

--- a/src/operators/sequential/selection/tournament.rs
+++ b/src/operators/sequential/selection/tournament.rs
@@ -60,7 +60,7 @@ where
         }
 
         // Clone the selected individual
-        let selected = best.clone();
+        let selected = best.clone_genome_only();
 
         Offspring::Single(selected)
     }

--- a/src/phenotype/bytecode.rs
+++ b/src/phenotype/bytecode.rs
@@ -60,9 +60,9 @@ impl<T> Bytecode<T> {
 impl<T: Instruction> Bytecode<T> {
     /// Executes the bytecode program with the given input, returning the final stack value.
     pub fn run(&self, input: &T::Input) -> T::Value {
-        let mut stack = Vec::new();
+        let mut stack: vecpool::PoolVec<T::Value> = vecpool::PoolVec::new();
         for instruction in &self.0 {
-            instruction.execute(&mut stack, input);
+            instruction.execute(&mut *stack, input);
         }
         stack.pop().unwrap_or_default()
     }
@@ -70,11 +70,11 @@ impl<T: Instruction> Bytecode<T> {
 
 /// Builder that collects terminals into a [`Bytecode`] program.
 #[derive(Debug)]
-pub struct BytecodeBuilder<T>(Vec<T>);
+pub struct BytecodeBuilder<T>(vecpool::PoolVec<T>);
 
 impl<T> Default for BytecodeBuilder<T> {
     fn default() -> Self {
-        Self(Vec::new())
+        Self(vecpool::PoolVec::new())
     }
 }
 
@@ -88,7 +88,7 @@ impl<T: Instruction> PhenotypeBuilder<T> for BytecodeBuilder<T> {
     }
 
     fn finish(self) -> Bytecode<T> {
-        Bytecode(self.0)
+        Bytecode(self.0.into_vec())
     }
 }
 


### PR DESCRIPTION
# Summary

  Added criterion benchmarks and implemented several performance optimizations. A new
  transform method on GeneticOperator that enables zero-copy mutation through Pipeline.

  # Changes

  ## New transform method on GeneticOperator trait:

  Pipeline now calls transform(state: State<G, F>, ...) instead of apply(&State<G, F>, ...) for chained operators. Since transform receives owned data, mutation operators can modify genomes
  in place without cloning. The default implementation delegates to apply, so existing custom operators work unchanged. Built-in RandomReset, SegmentDuplication, and SegmentDeletion
  override transform for in-place mutation.

  ## Supporting additions:

  - Individual::mutate_genome(self, f) — consumes individual, applies closure to genome, returns new individual with fresh fitness cell
  - Individual::clone_genome_only(&self) — clones genome without copying cached fitness (used in TournamentSelection)

  Allocation reduction via vecpool:

  - All internal short-lived Vecs (mapper stacks, populations, operator intermediates) now recycle buffers from a thread-local pool
  - Crossover uses pre-allocated Vec::with_capacity + extend_from_slice instead of [].concat()

  ## Benchmarks:

  - Added benches/genetic_operators.rs — crossover, mutation, selection, initialization, combinators, GE mapping
  - Added benches/algorithm.rs — full EA run, GE run (builder & macro grammar), experiment runner

  ## Documentation:

  - Expanded GeneticOperator trait docs with examples for both apply and transform
  - Fixed broken doc link in algorithm.rs
  - Added badges to README
  - Updated README dependency info and version references

  ## New dependencies

  - vecpool = "0.1.0" (unconditional)
  - criterion = "0.8" (dev-only)