### PR TITLE
  Add optional serde support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,8 @@ dependencies = [
  "evolve-derive",
  "pooled",
  "rand",
+ "serde",
+ "serde_json",
  "vecpool",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,15 +15,18 @@ members = ["evolve-derive"]
 
 [features]
 parallel = ["dep:pooled"]
+serde = ["dep:serde"]
 
 [dependencies]
 rand = "0.10.0"
 pooled = { version = "0.3", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
 evolve-derive = { path = "evolve-derive", version = "0.1" }
 vecpool = "0.1.0"
 
 [dev-dependencies]
 criterion = { version = "0.8", features = ["html_reports"] }
+serde_json = "1"
 
 [[bench]]
 name = "genetic_operators"

--- a/src/collector/basic.rs
+++ b/src/collector/basic.rs
@@ -45,6 +45,7 @@ impl Basic {
 
 /// The result of a completed algorithm run.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RunResult<G, F> {
     population: Population<G, F>,
     generations: usize,
@@ -77,6 +78,8 @@ impl<G, F, Fe, C> Collector<G, F, Fe, C> for Basic {
         }
     }
 }
+
+
 
 #[cfg(test)]
 mod test {

--- a/src/collector/standard.rs
+++ b/src/collector/standard.rs
@@ -56,6 +56,7 @@ impl<F> Default for Standard<F> {
 
 /// The final result of an algorithm run collected by [`Standard`].
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct RunResult<G, F> {
     population: Population<G, F>,
     generations: usize,
@@ -111,6 +112,7 @@ impl<G, F> RunResult<G, F> {
 
 /// A view into a single generation's recorded data.
 #[derive(Debug, Clone, Copy)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct GenerationRecord<'a, F> {
     best_fitness: &'a F,
     duration: Duration,

--- a/src/core/individual.rs
+++ b/src/core/individual.rs
@@ -85,3 +85,38 @@ impl<G, F> Individual<G, F> {
         Self::new(genome)
     }
 }
+
+#[cfg(feature = "serde")]
+impl<G, F> serde::Serialize for Individual<G, F>
+where
+    G: serde::Serialize,
+    F: serde::Serialize,
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        use serde::ser::SerializeStruct;
+        let mut s = serializer.serialize_struct("Individual", 2)?;
+        s.serialize_field("genome", &self.genome)?;
+        s.serialize_field("fitness", &self.try_fitness())?;
+        s.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, G, F> serde::Deserialize<'de> for Individual<G, F>
+where
+    G: serde::Deserialize<'de>,
+    F: serde::Deserialize<'de>,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        #[derive(serde::Deserialize)]
+        struct Data<G, F> {
+            genome: G,
+            fitness: Option<F>,
+        }
+        let data = Data::<G, F>::deserialize(deserializer)?;
+        Ok(match data.fitness {
+            Some(f) => Self::from_parts(data.genome, f),
+            None => Self::new(data.genome),
+        })
+    }
+}

--- a/src/core/offspring.rs
+++ b/src/core/offspring.rs
@@ -19,6 +19,7 @@ use crate::core::{individual::Individual, population::Population};
 /// assert_eq!(pop.len(), 1);
 /// ```
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Offspring<G, F> {
     /// A single individual produced by the operator.
     Single(Individual<G, F>),
@@ -47,3 +48,5 @@ impl<G, F> Offspring<G, F> {
         }
     }
 }
+
+

--- a/src/core/population.rs
+++ b/src/core/population.rs
@@ -207,3 +207,26 @@ impl<G: Clone, F: Clone> Clone for Population<G, F> {
         }
     }
 }
+
+#[cfg(feature = "serde")]
+impl<G, F> serde::Serialize for Population<G, F>
+where
+    G: serde::Serialize,
+    F: serde::Serialize,
+{
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.collect_seq(self.iter())
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de, G, F> serde::Deserialize<'de> for Population<G, F>
+where
+    G: serde::Deserialize<'de>,
+    F: serde::Deserialize<'de>,
+{
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let individuals = Vec::<Individual<G, F>>::deserialize(deserializer)?;
+        Ok(Self::from_individuals(individuals))
+    }
+}

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -9,6 +9,7 @@ use crate::{
 /// Passed to [`GeneticOperator::apply`] so
 /// operators can read the current population and generation number.
 #[derive(Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct State<G, F> {
     population: Population<G, F>,
     generation: usize,
@@ -59,3 +60,5 @@ impl<G, F> State<G, F> {
         self.population
     }
 }
+
+

--- a/tests/serde.rs
+++ b/tests/serde.rs
@@ -1,0 +1,109 @@
+#![cfg(feature = "serde")]
+
+use evolve::core::{
+    individual::Individual,
+    offspring::Offspring,
+    population::Population,
+    state::State,
+};
+
+#[test]
+fn individual_with_fitness_round_trip() {
+    let ind = Individual::<Vec<u8>, u32>::from_parts(vec![1, 2, 3], 6);
+    let json = serde_json::to_string(&ind).unwrap();
+    let de: Individual<Vec<u8>, u32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(de.genome(), &vec![1, 2, 3]);
+    assert_eq!(de.try_fitness(), Some(&6));
+}
+
+#[test]
+fn individual_without_fitness_round_trip() {
+    let ind = Individual::<Vec<u8>, u32>::new(vec![4, 5, 6]);
+    let json = serde_json::to_string(&ind).unwrap();
+    let de: Individual<Vec<u8>, u32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(de.genome(), &vec![4, 5, 6]);
+    assert_eq!(de.try_fitness(), None);
+}
+
+#[test]
+fn population_round_trip() {
+    let pop = Population::from_individuals(vec![
+        Individual::from_parts(1u32, 10i32),
+        Individual::from_parts(2, 20),
+    ]);
+    let json = serde_json::to_string(&pop).unwrap();
+    let de: Population<u32, i32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(de.len(), 2);
+    assert_eq!(de.iter().next().unwrap().try_fitness(), Some(&10));
+}
+
+#[test]
+fn state_round_trip() {
+    let pop = Population::from_individuals(vec![Individual::from_parts(1u32, 10i32)]);
+    let state = State::new(pop, 5);
+    let json = serde_json::to_string(&state).unwrap();
+    let de: State<u32, i32> = serde_json::from_str(&json).unwrap();
+    assert_eq!(de.generation(), 5);
+    assert_eq!(de.population().len(), 1);
+}
+
+#[test]
+fn offspring_single_round_trip() {
+    let off = Offspring::<u32, i32>::Single(Individual::from_parts(42, 100));
+    let json = serde_json::to_string(&off).unwrap();
+    let de: Offspring<u32, i32> = serde_json::from_str(&json).unwrap();
+    match de {
+        Offspring::Single(ind) => {
+            assert_eq!(ind.genome(), &42);
+            assert_eq!(ind.try_fitness(), Some(&100));
+        }
+        _ => panic!("expected Single"),
+    }
+}
+
+#[test]
+fn offspring_multiple_round_trip() {
+    let pop = Population::from_individuals(vec![
+        Individual::from_parts(1u32, 10i32),
+        Individual::from_parts(2, 20),
+    ]);
+    let off = Offspring::Multiple(pop);
+    let json = serde_json::to_string(&off).unwrap();
+    let de: Offspring<u32, i32> = serde_json::from_str(&json).unwrap();
+    match de {
+        Offspring::Multiple(p) => assert_eq!(p.len(), 2),
+        _ => panic!("expected Multiple"),
+    }
+}
+
+#[test]
+fn basic_run_result_round_trip() {
+    use evolve::collector::basic::RunResult;
+    let json = r#"{"population":[{"genome":1,"fitness":10}],"generations":5}"#;
+    let de: RunResult<u32, i32> = serde_json::from_str(json).unwrap();
+    assert_eq!(de.generations(), 5);
+    assert_eq!(de.population().len(), 1);
+    let re = serde_json::to_string(&de).unwrap();
+    assert_eq!(re, json);
+}
+
+#[test]
+fn standard_run_result_round_trip() {
+    use evolve::collector::standard::RunResult;
+    let json = r#"{"population":[{"genome":1,"fitness":10}],"generations":3,"total_duration":{"secs":1,"nanos":0},"best_fitness":[10,10,10],"generation_durations":[{"secs":0,"nanos":100},{"secs":0,"nanos":200},{"secs":0,"nanos":300}]}"#;
+    let de: RunResult<u32, i32> = serde_json::from_str(json).unwrap();
+    assert_eq!(de.generations(), 3);
+    assert_eq!(de.best_fitness().len(), 3);
+    let re = serde_json::to_string(&de).unwrap();
+    assert_eq!(re, json);
+}
+
+#[test]
+fn generation_record_serializes() {
+    use evolve::collector::standard::RunResult;
+    let json = r#"{"population":[{"genome":1,"fitness":10}],"generations":1,"total_duration":{"secs":0,"nanos":0},"best_fitness":[10],"generation_durations":[{"secs":0,"nanos":500}]}"#;
+    let result: RunResult<u32, i32> = serde_json::from_str(json).unwrap();
+    let record = result.generation(0).unwrap();
+    let record_json = serde_json::to_string(&record).unwrap();
+    assert_eq!(record_json, r#"{"best_fitness":10,"duration":{"secs":0,"nanos":500}}"#);
+}


### PR DESCRIPTION
Add Serialize and Deserialize implementations for core data types behind an optional serde feature flag.

#  Changes

  - Add serde optional dependency and serde = ["dep:serde"] feature
  - Add serde_json dev-dependency for round-trip tests
  - Custom Serialize/Deserialize impls for Individual<G, F> and Population<G, F> (required due to OnceCell/PoolVec internals)
  - Derive Serialize/Deserialize for State, Offspring, basic::RunResult, standard::RunResult
  - Derive Serialize only for GenerationRecord (borrows data, cannot deserialize)