### PR TITLE
Add custom Mapper trait for GE module

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A generic, composable genetic algorithm framework for Rust.
 - `Maximize` and `Minimize` fitness comparators out of the box
 - Closures work as fitness evaluators and comparators via blanket trait impls
 - Minimal dependencies: `rand` and `vecpool` (optional `pooled` for parallel execution)
+- Optional `serde` support for serializing populations and results
 
 ## Available Operators
 
@@ -251,7 +252,7 @@ use evolve::{
 };
 use std::num::NonZero;
 
-let fitness = GeFitness::<MyGrammar, u8, f64, _, BytecodeBuilder<Sym>>::new(
+let fitness = GeFitness::<MyGrammar, u8, f64, _, BytecodeBuilder<Sym>, _>::new(
     MyGrammar,
     3,
     |program: &Bytecode<Sym>| {
@@ -284,6 +285,31 @@ let result = ea.run();
 ### Variable-length operators
 
 GE benefits from variable-length genomes. Use `RangedRandom` for initialization (produces genomes of random length within a range) and the variable-length mutation operators `SegmentDuplication` and `SegmentDeletion` to explore different codon lengths during evolution.
+
+### Custom mappers
+
+The `Mapper` trait allows custom strategies for mapping codon sequences to phenotypes. `StandardMapper` is the default (used automatically by `GeFitness::new()`). Use `GeFitness::with_mapper()` to plug in a custom implementation:
+
+```rust
+use evolve::mapper::{Mapper, StandardMapper};
+use evolve::grammar::GrammarDef;
+use evolve::phenotype::PhenotypeBuilder;
+use evolve::codon::Codon;
+
+struct MyMapper;
+
+impl Mapper for MyMapper {
+    fn map<G: GrammarDef, C: Codon, B: PhenotypeBuilder<G::Terminal>>(
+        &self, grammar: &G, codons: &[C], builder: B,
+    ) -> Option<B::Output> {
+        // Custom mapping logic
+        StandardMapper::new(3).map(grammar, codons, builder)
+    }
+}
+
+// Use with GeFitness:
+// let fitness = GeFitness::with_mapper(grammar, MyMapper, |program| { ... }, penalty);
+```
 
 ## Collectors
 
@@ -353,6 +379,23 @@ let results = Experiment::new(
 for (i, r) in results.iter().enumerate() {
     println!("Run {}: {} gens, {:?}", i, r.generations(), r.total_duration());
 }
+```
+
+## Serde Support
+
+Enable the `serde` feature to derive `Serialize` and `Deserialize` for core types (`Individual`, `Population`, `State`, `Offspring`) and collector results (`basic::RunResult`, `standard::RunResult`):
+
+```toml
+[dependencies]
+evolve = { version = "0.3", features = ["serde"] }
+```
+
+```rust
+use serde_json;
+
+let result = ea.run();
+let json = serde_json::to_string(result.population()).unwrap();
+println!("{json}");
 ```
 
 ## Contributing

--- a/benches/algorithm.rs
+++ b/benches/algorithm.rs
@@ -144,12 +144,10 @@ fn bench_experiment(c: &mut Criterion) {
 fn bench_ge_run(c: &mut Criterion) {
     c.bench_function("ge_run_100pop_50gen", |b| {
         b.iter(|| {
-            let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-                arithmetic_grammar(),
-                3,
-                |p: &TerminalCount| p.run(&()) as f64,
-                -1.0,
-            );
+            let fitness = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(arithmetic_grammar(),
+            3,
+            |p: &TerminalCount| p.run(&()) as f64,
+            -1.0,);
             let mut ga = EvolutionaryAlgorithm::new(
                 RangedRandom::<u8>::new(5..20),
                 MaxGenerations::new(50),
@@ -188,12 +186,10 @@ fn bench_ge_experiment(c: &mut Criterion) {
             Experiment::new(
                 move || {
                     seed += 1;
-                    let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-                        arithmetic_grammar(),
-                        3,
-                        |p: &TerminalCount| p.run(&()) as f64,
-                        -1.0,
-                    );
+                    let fitness = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(arithmetic_grammar(),
+                    3,
+                    |p: &TerminalCount| p.run(&()) as f64,
+                    -1.0,);
                     EvolutionaryAlgorithm::new(
                         RangedRandom::<u8>::new(5..20),
                         MaxGenerations::new(50),
@@ -234,12 +230,10 @@ fn bench_ge_experiment(c: &mut Criterion) {
 fn bench_ge_macro_run(c: &mut Criterion) {
     c.bench_function("ge_macro_run_100pop_50gen", |b| {
         b.iter(|| {
-            let fitness = GeFitness::<MacroGrammar, u8, f64, _, MacroCountBuilder>::new(
-                MacroGrammar,
-                3,
-                |p: &TerminalCount| p.run(&()) as f64,
-                -1.0,
-            );
+            let fitness = GeFitness::<MacroGrammar, u8, f64, _, MacroCountBuilder, _>::new(MacroGrammar,
+            3,
+            |p: &TerminalCount| p.run(&()) as f64,
+            -1.0,);
             let mut ga = EvolutionaryAlgorithm::new(
                 RangedRandom::<u8>::new(5..20),
                 MaxGenerations::new(50),
@@ -279,12 +273,10 @@ fn bench_ge_macro_experiment(c: &mut Criterion) {
                 move || {
                     seed += 1;
                     let fitness =
-                        GeFitness::<MacroGrammar, u8, f64, _, MacroCountBuilder>::new(
-                            MacroGrammar,
-                            3,
-                            |p: &TerminalCount| p.run(&()) as f64,
-                            -1.0,
-                        );
+                        GeFitness::<MacroGrammar, u8, f64, _, MacroCountBuilder, _>::new(MacroGrammar,
+                        3,
+                        |p: &TerminalCount| p.run(&()) as f64,
+                        -1.0,);
                     EvolutionaryAlgorithm::new(
                         RangedRandom::<u8>::new(5..20),
                         MaxGenerations::new(50),

--- a/benches/genetic_operators.rs
+++ b/benches/genetic_operators.rs
@@ -430,12 +430,10 @@ fn bench_ge_mapping(c: &mut Criterion) {
         .start("expr")
         .build();
 
-    let ge = GeFitness::<_, u8, f64, _, ExprBuilder>::new(
-        grammar,
-        3,
-        |p: &Expr| p.0,
-        0.0,
-    );
+    let ge = GeFitness::<_, u8, f64, _, ExprBuilder, _>::new(grammar,
+    3,
+    |p: &Expr| p.0,
+    0.0,);
 
     c.bench_function("ge_mapping", |b| {
         let genome: Vec<u8> = vec![0, 1, 0, 2, 1, 0, 2, 1, 0, 1, 2, 0, 1, 2, 0];

--- a/src/fitness.rs
+++ b/src/fitness.rs
@@ -110,7 +110,7 @@ where
 use std::marker::PhantomData;
 
 use crate::grammar::grammar_def::GrammarDef;
-use crate::grammar::mapper::{Codon, map};
+use crate::grammar::mapper::{Codon, Mapper, StandardMapper};
 use crate::phenotype::PhenotypeBuilder;
 
 /// A fitness evaluator for grammatical evolution.
@@ -150,30 +150,28 @@ use crate::phenotype::PhenotypeBuilder;
 ///     .start("s")
 ///     .build();
 ///
-/// let ge = GeFitness::<_, u8, _, _, LenBuilder>::new(grammar, 3, |p: &Len| p.run(&()), 0);
+/// let ge = GeFitness::<_, u8, _, _, LenBuilder, _>::new(grammar, 3, |p: &Len| p.run(&()), 0);
 /// assert_eq!(ge.evaluate(&vec![0u8]), 2);  // production 0 has 2 terminals
 /// assert_eq!(ge.evaluate(&vec![1u8]), 1);  // production 1 has 1 terminal
 /// ```
 #[derive(Debug)]
-pub struct GeFitness<G, C, F, E, B> {
+pub struct GeFitness<G, C, F, E, B, M> {
     grammar: G,
-    max_wraps: usize,
+    mapper: M,
     evaluator: E,
     penalty: F,
     _marker: PhantomData<(C, B)>,
 }
 
-impl<G, C, F, E, B> GeFitness<G, C, F, E, B> {
-    /// Creates a GE fitness evaluator.
-    ///
-    /// - `grammar` — the grammar to map through
-    /// - `max_wraps` — maximum codon wraps before declaring invalid
-    /// - `evaluator` — receives the phenotype and returns a fitness score
-    /// - `penalty` — fitness for individuals that fail to map
-    pub fn new(grammar: G, max_wraps: usize, evaluator: E, penalty: F) -> Self {
+/// Type alias for GeFitness using the standard mapper.
+pub type StandardGeFitness<G, C, F, E, B> = GeFitness<G, C, F, E, B, StandardMapper>;
+
+impl<G, C, F, E, B, M> GeFitness<G, C, F, E, B, M> {
+    /// Creates a GE fitness evaluator with a custom mapper.
+    pub fn with_mapper(grammar: G, mapper: M, evaluator: E, penalty: F) -> Self {
         Self {
             grammar,
-            max_wraps,
+            mapper,
             evaluator,
             penalty,
             _marker: PhantomData,
@@ -189,12 +187,25 @@ impl<G, C, F, E, B> GeFitness<G, C, F, E, B> {
         G::Terminal: Clone,
         C: Codon,
         B: PhenotypeBuilder<G::Terminal> + Default,
+        M: Mapper,
     {
-        map(&self.grammar, genome, self.max_wraps, B::default())
+        self.mapper.map(&self.grammar, genome, B::default())
     }
 }
 
-impl<G, C, F, E, B> FitnessEvaluator<Vec<C>, F> for GeFitness<G, C, F, E, B>
+impl<G, C, F, E, B> GeFitness<G, C, F, E, B, StandardMapper> {
+    /// Creates a GE fitness evaluator using the standard mapper.
+    ///
+    /// - `grammar` — the grammar to map through
+    /// - `max_wraps` — maximum codon wraps before declaring invalid
+    /// - `evaluator` — receives the phenotype and returns a fitness score
+    /// - `penalty` — fitness for individuals that fail to map
+    pub fn new(grammar: G, max_wraps: usize, evaluator: E, penalty: F) -> Self {
+        Self::with_mapper(grammar, StandardMapper::new(max_wraps), evaluator, penalty)
+    }
+}
+
+impl<G, C, F, E, B, M> FitnessEvaluator<Vec<C>, F> for GeFitness<G, C, F, E, B, M>
 where
     G: GrammarDef,
     G::Terminal: Clone,
@@ -202,9 +213,10 @@ where
     F: Clone,
     B: PhenotypeBuilder<G::Terminal> + Default,
     E: Fn(&B::Output) -> F,
+    M: Mapper,
 {
     fn evaluate(&self, genome: &Vec<C>) -> F {
-        match map(&self.grammar, genome, self.max_wraps, B::default()) {
+        match self.mapper.map(&self.grammar, genome, B::default()) {
             Some(phenotype) => (self.evaluator)(&phenotype),
             None => self.penalty.clone(),
         }
@@ -248,7 +260,7 @@ mod ge_fitness_tests {
 
     #[test]
     fn valid_mapping_calls_evaluator() {
-        let fitness = GeFitness::<_, u8, f64, _, ProgramBuilder>::new(
+        let fitness = GeFitness::<_, u8, f64, _, ProgramBuilder, _>::new(
             simple_grammar(),
             0,
             |p: &Program| p.run(&()).len() as f64,
@@ -267,7 +279,7 @@ mod ge_fitness_tests {
             .start("expr")
             .build();
 
-        let fitness = GeFitness::<_, u8, f64, _, ProgramBuilder>::new(
+        let fitness = GeFitness::<_, u8, f64, _, ProgramBuilder, _>::new(
             g,
             0,
             |p: &Program| p.run(&()).len() as f64,

--- a/src/grammar.rs
+++ b/src/grammar.rs
@@ -3,6 +3,8 @@
 pub mod grammar_def;
 pub mod mapper;
 
+pub use mapper::{Codon, Mapper, StandardMapper};
+
 use std::collections::HashMap;
 use std::hash::Hash;
 

--- a/src/grammar/mapper.rs
+++ b/src/grammar/mapper.rs
@@ -36,63 +36,90 @@ impl Codon for usize {
     }
 }
 
-/// Maps a codon sequence through a grammar using a [`PhenotypeBuilder`].
-///
-/// Returns `None` if codons are exhausted after `max_wraps` wraps before all
-/// non-terminals are expanded.
-pub(crate) fn map<G: GrammarDef, C: Codon, B: PhenotypeBuilder<G::Terminal>>(
-    grammar: &G,
-    codons: &[C],
-    max_wraps: usize,
-    mut builder: B,
-) -> Option<B::Output> {
-    let mut stack: PoolVec<G::Symbol> = PoolVec::new();
-    stack.push(grammar.start());
-    let mut end_rule_stack: PoolVec<usize> = PoolVec::new();
-    let mut codon_idx: usize = 0;
+/// Trait for codon-to-phenotype mapping strategies.
+pub trait Mapper {
+    /// Maps a codon sequence through a grammar into a phenotype.
+    ///
+    /// Returns `None` if the mapping fails (e.g., codons exhausted).
+    fn map<G: GrammarDef, C: Codon, B: PhenotypeBuilder<G::Terminal>>(
+        &self,
+        grammar: &G,
+        codons: &[C],
+        builder: B,
+    ) -> Option<B::Output>;
+}
 
-    while let Some(symbol) = stack.pop() {
-        if grammar.is_terminal(symbol) {
-            builder.push(Event::Terminal(grammar.terminal_value(symbol)));
-        } else {
-            let n = grammar.num_productions(symbol);
-            let choice = if n == 1 {
-                0
-            } else {
-                if codons.is_empty() {
-                    return None;
-                }
-                let current_wrap = codon_idx / codons.len();
-                if current_wrap > max_wraps {
-                    return None;
-                }
-                let c = codons[codon_idx % codons.len()].as_usize() % n;
-                codon_idx += 1;
-                c
-            };
+/// The standard GE mapping algorithm: stack-based derivation with codon
+/// modulo selection, single-production optimization, and wrapping.
+#[derive(Debug, Clone, Copy)]
+pub struct StandardMapper {
+    /// Maximum number of times the codon sequence may wrap before
+    /// declaring the mapping invalid.
+    pub max_wraps: usize,
+}
 
-            builder.push(Event::BeginRule);
-            let prod = grammar.production(symbol, choice);
-            for &s in prod.iter().rev() {
-                stack.push(s);
-            }
-            end_rule_stack.push(prod.len());
-            continue;
-        }
-
-        // After processing a terminal, decrement parent counters.
-        while let Some(count) = end_rule_stack.last_mut() {
-            *count -= 1;
-            if *count == 0 {
-                end_rule_stack.pop();
-                builder.push(Event::EndRule);
-            } else {
-                break;
-            }
-        }
+impl StandardMapper {
+    /// Creates a new `StandardMapper` with the given maximum wrap count.
+    pub fn new(max_wraps: usize) -> Self {
+        Self { max_wraps }
     }
+}
 
-    Some(builder.finish())
+impl Mapper for StandardMapper {
+    fn map<G: GrammarDef, C: Codon, B: PhenotypeBuilder<G::Terminal>>(
+        &self,
+        grammar: &G,
+        codons: &[C],
+        mut builder: B,
+    ) -> Option<B::Output> {
+        let mut stack: PoolVec<G::Symbol> = PoolVec::new();
+        stack.push(grammar.start());
+        let mut end_rule_stack: PoolVec<usize> = PoolVec::new();
+        let mut codon_idx: usize = 0;
+
+        while let Some(symbol) = stack.pop() {
+            if grammar.is_terminal(symbol) {
+                builder.push(Event::Terminal(grammar.terminal_value(symbol)));
+            } else {
+                let n = grammar.num_productions(symbol);
+                let choice = if n == 1 {
+                    0
+                } else {
+                    if codons.is_empty() {
+                        return None;
+                    }
+                    let current_wrap = codon_idx / codons.len();
+                    if current_wrap > self.max_wraps {
+                        return None;
+                    }
+                    let c = codons[codon_idx % codons.len()].as_usize() % n;
+                    codon_idx += 1;
+                    c
+                };
+
+                builder.push(Event::BeginRule);
+                let prod = grammar.production(symbol, choice);
+                for &s in prod.iter().rev() {
+                    stack.push(s);
+                }
+                end_rule_stack.push(prod.len());
+                continue;
+            }
+
+            // After processing a terminal, decrement parent counters.
+            while let Some(count) = end_rule_stack.last_mut() {
+                *count -= 1;
+                if *count == 0 {
+                    end_rule_stack.pop();
+                    builder.push(Event::EndRule);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        Some(builder.finish())
+    }
 }
 
 #[cfg(test)]
@@ -129,21 +156,21 @@ mod test {
     #[test]
     fn simple_terminal() {
         let g = expr_grammar();
-        let result = map(&g, &[1u8], 0, ProgramBuilder::default());
+        let result = StandardMapper::new(0).map(&g, &[1u8], ProgramBuilder::default());
         assert_eq!(result.unwrap().0, "x");
     }
 
     #[test]
     fn recursive_expansion() {
         let g = expr_grammar();
-        let result = map(&g, &[0u8, 1, 0, 2], 0, ProgramBuilder::default());
+        let result = StandardMapper::new(0).map(&g, &[0u8, 1, 0, 2], ProgramBuilder::default());
         assert_eq!(result.unwrap().0, "x+1");
     }
 
     #[test]
     fn wrapping() {
         let g = expr_grammar();
-        let result = map(&g, &[0u8], 1, ProgramBuilder::default());
+        let result = StandardMapper::new(1).map(&g, &[0u8], ProgramBuilder::default());
         assert_eq!(result, None);
     }
 
@@ -155,7 +182,7 @@ mod test {
             .start("s")
             .build();
 
-        let result = map(&g, &[0u8], 0, ProgramBuilder::default());
+        let result = StandardMapper::new(0).map(&g, &[0u8], ProgramBuilder::default());
         assert_eq!(result.unwrap().0, "hi");
     }
 
@@ -166,7 +193,7 @@ mod test {
             .start("s")
             .build();
 
-        let result = map(&g, &[0u8], 0, ProgramBuilder::default());
+        let result = StandardMapper::new(0).map(&g, &[0u8], ProgramBuilder::default());
         assert_eq!(result.unwrap().0, "hello");
     }
 
@@ -177,7 +204,7 @@ mod test {
             .start("s")
             .build();
 
-        let result = map(&g, &[] as &[u8], 0, ProgramBuilder::default());
+        let result = StandardMapper::new(0).map(&g, &[] as &[u8], ProgramBuilder::default());
         assert_eq!(result, None);
     }
 
@@ -189,11 +216,11 @@ mod test {
             .build();
 
         // u8::MAX (255) % 3 == 0 → picks "a"
-        let result = map(&g, &[u8::MAX], 0, ProgramBuilder::default());
+        let result = StandardMapper::new(0).map(&g, &[u8::MAX], ProgramBuilder::default());
         assert_eq!(result.unwrap().0, "a");
 
         // 254 % 3 == 2 → picks "c"
-        let result = map(&g, &[254u8], 0, ProgramBuilder::default());
+        let result = StandardMapper::new(0).map(&g, &[254u8], ProgramBuilder::default());
         assert_eq!(result.unwrap().0, "c");
     }
 
@@ -220,7 +247,7 @@ mod test {
             .start("expr")
             .build();
 
-        let result = map(&grammar, &[0u8], 0, TermListBuilder::default());
+        let result = StandardMapper::new(0).map(&grammar, &[0u8], TermListBuilder::default());
         assert_eq!(result.unwrap().0, vec!["x"]);
     }
 }

--- a/tests/custom_grammar.rs
+++ b/tests/custom_grammar.rs
@@ -181,12 +181,10 @@ fn phenotype_run_subtraction() {
 fn ge_fitness_produces_valid_phenotype() {
     // Codons: [1, 0] → Expr picks prod 1 (Val), Val picks prod 0 (X)
     // Result: StackMachine([X]), run(2.0) = 2.0
-    let ge = GeFitness::<_, u8, f64, _, StackBuilder>::new(
-        MathGrammar,
-        3,
-        |p: &StackMachine| p.run(&2.0),
-        -999.0,
-    );
+    let ge = GeFitness::<_, u8, f64, _, StackBuilder, _>::new(MathGrammar,
+    3,
+    |p: &StackMachine| p.run(&2.0),
+    -999.0,);
     assert_eq!(ge.evaluate(&vec![1u8, 0]), 2.0);
 }
 
@@ -220,24 +218,20 @@ fn ge_fitness_complex_expression() {
     //     Val → 1%2=1: [One]
     //   Op → 0%2=0: [Add]
     // Terminals in order: X, One, Add → StackMachine([X, One, Add]) → x + 1
-    let ge = GeFitness::<_, u8, f64, _, StackBuilder>::new(
-        MathGrammar,
-        3,
-        |p: &StackMachine| p.run(&5.0),
-        -999.0,
-    );
+    let ge = GeFitness::<_, u8, f64, _, StackBuilder, _>::new(MathGrammar,
+    3,
+    |p: &StackMachine| p.run(&5.0),
+    -999.0,);
     assert_eq!(ge.evaluate(&vec![0u8, 1, 0, 1, 1, 0]), 6.0); // x + 1 = 5 + 1 = 6
 }
 
 #[test]
 fn ge_fitness_invalid_returns_penalty() {
     // All-recursive codons with 0 wraps should exhaust
-    let ge = GeFitness::<_, u8, f64, _, StackBuilder>::new(
-        MathGrammar,
-        0,
-        |p: &StackMachine| p.run(&1.0),
-        -999.0,
-    );
+    let ge = GeFitness::<_, u8, f64, _, StackBuilder, _>::new(MathGrammar,
+    0,
+    |p: &StackMachine| p.run(&1.0),
+    -999.0,);
     // Single codon 0 picks recursive [Expr, Expr, Op] repeatedly
     assert_eq!(ge.evaluate(&vec![0u8]), -999.0);
 }

--- a/tests/ge.rs
+++ b/tests/ge.rs
@@ -58,12 +58,10 @@ fn arithmetic_grammar() -> Grammar<&'static str> {
 
 #[test]
 fn ge_runs_to_completion() {
-    let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-        arithmetic_grammar(),
-        3,
-        |p: &TerminalCount| p.run(&()) as f64,
-        -1.0,
-    );
+    let fitness = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(arithmetic_grammar(),
+    3,
+    |p: &TerminalCount| p.run(&()) as f64,
+    -1.0,);
 
     let mut ga = EvolutionaryAlgorithm::new(
         RangedRandom::<u8>::new(5..20),
@@ -87,12 +85,10 @@ fn ge_runs_to_completion() {
 
 #[test]
 fn ge_with_segment_operators() {
-    let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-        arithmetic_grammar(),
-        3,
-        |p: &TerminalCount| p.run(&()) as f64,
-        -1.0,
-    );
+    let fitness = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(arithmetic_grammar(),
+    3,
+    |p: &TerminalCount| p.run(&()) as f64,
+    -1.0,);
 
     let mut ga = EvolutionaryAlgorithm::new(
         RangedRandom::<u8>::new(5..20),
@@ -121,12 +117,10 @@ fn ge_with_segment_operators() {
 #[test]
 fn ge_best_has_valid_phenotype() {
     let grammar = arithmetic_grammar();
-    let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-        grammar.clone(),
-        3,
-        |p: &TerminalCount| p.run(&()) as f64,
-        -1.0,
-    );
+    let fitness = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(grammar.clone(),
+    3,
+    |p: &TerminalCount| p.run(&()) as f64,
+    -1.0,);
 
     let mut ga = EvolutionaryAlgorithm::new(
         RangedRandom::<u8>::new(5..20),
@@ -147,12 +141,10 @@ fn ge_best_has_valid_phenotype() {
 
     let result = ga.run();
 
-    let fe = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-        grammar.clone(),
-        3,
-        |p: &TerminalCount| p.run(&()) as f64,
-        -1.0,
-    );
+    let fe = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(grammar.clone(),
+    3,
+    |p: &TerminalCount| p.run(&()) as f64,
+    -1.0,);
 
     let best = result.population().best(&fe, &Maximize);
     let fitness = fe.evaluate(best.genome());
@@ -203,12 +195,10 @@ fn op_grammar() -> Grammar<Op> {
 fn ge_bytecode_integration() {
     let grammar = op_grammar();
 
-    let fitness = GeFitness::<_, u8, i32, _, BytecodeBuilder<Op>>::new(
-        grammar.clone(),
-        2,
-        |p: &Bytecode<Op>| p.run(&()),
-        i32::MIN,
-    );
+    let fitness = GeFitness::<_, u8, i32, _, BytecodeBuilder<Op>, _>::new(grammar.clone(),
+    2,
+    |p: &Bytecode<Op>| p.run(&()),
+    i32::MIN,);
 
     let mut ga = EvolutionaryAlgorithm::new(
         RangedRandom::<u8>::new(5..15),
@@ -229,12 +219,10 @@ fn ge_bytecode_integration() {
 
     let result = ga.run();
 
-    let fe = GeFitness::<_, u8, i32, _, BytecodeBuilder<Op>>::new(
-        grammar.clone(),
-        2,
-        |p: &Bytecode<Op>| p.run(&()),
-        i32::MIN,
-    );
+    let fe = GeFitness::<_, u8, i32, _, BytecodeBuilder<Op>, _>::new(grammar.clone(),
+    2,
+    |p: &Bytecode<Op>| p.run(&()),
+    i32::MIN,);
 
     let best = result.population().best(&fe, &Maximize);
     let fitness = fe.evaluate(best.genome());
@@ -251,7 +239,7 @@ fn ge_improves_fitness_over_generations() {
     let fitness_fn = |p: &TerminalCount| p.run(&()) as f64;
 
     let make_fitness =
-        || GeFitness::<_, u8, f64, _, CountBuilder>::new(arithmetic_grammar(), 3, fitness_fn, -1.0);
+        || GeFitness::<_, u8, f64, _, CountBuilder, _>::new(arithmetic_grammar(), 3, fitness_fn, -1.0);
 
     let ops = || {
         Fill::from_population_size(Pipeline::new((
@@ -302,12 +290,10 @@ fn ge_improves_fitness_over_generations() {
 
 #[test]
 fn ge_with_fixed_length_genome() {
-    let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-        arithmetic_grammar(),
-        3,
-        |p: &TerminalCount| p.run(&()) as f64,
-        -1.0,
-    );
+    let fitness = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(arithmetic_grammar(),
+    3,
+    |p: &TerminalCount| p.run(&()) as f64,
+    -1.0,);
 
     let mut ea = EvolutionaryAlgorithm::new(
         RangedRandom::<u8>::new(20..21),

--- a/tests/grammar_macro.rs
+++ b/tests/grammar_macro.rs
@@ -44,12 +44,10 @@ fn macro_grammar_def_works() {
 
 #[test]
 fn macro_grammar_maps_to_bytecode() {
-    let fitness = GeFitness::<Grammar, u8, f64, _, BytecodeBuilder<Symbol>>::new(
-        Grammar,
-        0,
-        |p: &Bytecode<Symbol>| p.run(&5.0),
-        f64::NAN,
-    );
+    let fitness = GeFitness::<Grammar, u8, f64, _, BytecodeBuilder<Symbol>, _>::new(Grammar,
+    0,
+    |p: &Bytecode<Symbol>| p.run(&5.0),
+    f64::NAN,);
     // Codons: 1 % 2 = 1 → Val, then 0 % 2 = 0 → X
     let result = fitness.evaluate(&vec![1u8, 0]);
     assert_eq!(result, 5.0);
@@ -57,12 +55,10 @@ fn macro_grammar_maps_to_bytecode() {
 
 #[test]
 fn macro_grammar_runs_expression() {
-    let fitness = GeFitness::<Grammar, u8, f64, _, BytecodeBuilder<Symbol>>::new(
-        Grammar,
-        0,
-        |p: &Bytecode<Symbol>| p.run(&3.0),
-        f64::NAN,
-    );
+    let fitness = GeFitness::<Grammar, u8, f64, _, BytecodeBuilder<Symbol>, _>::new(Grammar,
+    0,
+    |p: &Bytecode<Symbol>| p.run(&3.0),
+    f64::NAN,);
     // Codons: 0 → Expr Expr BinOp (binary)
     //         1 → Val (left)
     //         0 → X (left val)
@@ -76,16 +72,14 @@ fn macro_grammar_runs_expression() {
 
 #[test]
 fn macro_grammar_with_ge_fitness() {
-    let fitness = GeFitness::<Grammar, u8, f64, _, BytecodeBuilder<Symbol>>::new(
-        Grammar,
-        3,
-        |program: &Bytecode<Symbol>| {
-            // Test on x = 2: target is x + 1 = 3
-            let result = program.run(&2.0);
-            (result - 3.0).abs()
-        },
-        f64::MAX,
-    );
+    let fitness = GeFitness::<Grammar, u8, f64, _, BytecodeBuilder<Symbol>, _>::new(Grammar,
+    3,
+    |program: &Bytecode<Symbol>| {
+        // Test on x = 2: target is x + 1 = 3
+        let result = program.run(&2.0);
+        (result - 3.0).abs()
+    },
+    f64::MAX,);
 
     // Codons that produce x + 1
     let codons = vec![0u8, 1, 0, 1, 1, 0];

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -376,12 +376,10 @@ fn parallel_ge_runs_to_completion() {
         .start("expr")
         .build();
 
-    let fitness = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-        grammar,
-        3,
-        |p: &TerminalCount| p.run(&()) as f64,
-        -1.0,
-    );
+    let fitness = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(grammar,
+    3,
+    |p: &TerminalCount| p.run(&()) as f64,
+    -1.0,);
 
     let mut ga = EvolutionaryAlgorithm::builder(nz(100))
         .initializer(RangedRandom::<u8>::new(5..20))
@@ -395,18 +393,16 @@ fn parallel_ge_runs_to_completion() {
 
     let result = ga.run();
 
-    let fe = GeFitness::<_, u8, f64, _, CountBuilder>::new(
-        Grammar::builder()
-            .rule("expr", &[&["expr", "op", "expr"], &["var"], &["const"]])
-            .rule("op", &[&["+"], &["-"], &["*"]])
-            .rule("var", &[&["x"], &["y"]])
-            .rule("const", &[&["1"], &["2"]])
-            .start("expr")
-            .build(),
-        3,
-        |p: &TerminalCount| p.run(&()) as f64,
-        -1.0,
-    );
+    let fe = GeFitness::<_, u8, f64, _, CountBuilder, _>::new(Grammar::builder()
+        .rule("expr", &[&["expr", "op", "expr"], &["var"], &["const"]])
+        .rule("op", &[&["+"], &["-"], &["*"]])
+        .rule("var", &[&["x"], &["y"]])
+        .rule("const", &[&["1"], &["2"]])
+        .start("expr")
+        .build(),
+    3,
+    |p: &TerminalCount| p.run(&()) as f64,
+    -1.0,);
 
     let best_fitness = fe.evaluate(result.population().best(&fe, &Maximize).genome());
     assert!(


### PR DESCRIPTION
Extract the hardcoded GE mapping function into a Mapper trait, enabling users to provide custom codon-to-phenotype mapping strategies. The existing algorithm is preserved as
  StandardMapper.

  # Changes:

  - Added pub trait Mapper with a generic map method in src/grammar/mapper.rs
  - Added StandardMapper struct (configurable max_wraps) implementing the existing mapping algorithm
  - Made GeFitness generic over M: Mapper (6th type parameter)
  - Added GeFitness::with_mapper() constructor for custom mappers
  - Kept GeFitness::new() ergonomic (constrained to StandardMapper, no API change for common case)
  - Added StandardGeFitness type alias for convenience
  - Removed the free pub(crate) fn map() function
  - Updated re-exports in src/grammar.rs (Mapper, StandardMapper, Codon)
  - Updated README: custom mapper docs, serde feature docs, fixed outdated turbofish